### PR TITLE
chore(ci): Setup Python with uv

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -76,12 +76,8 @@ jobs:
 
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v7
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-          allow-prereleases: true
 
       - name: Install git-annex
         run: uv tool install git-annex


### PR DESCRIPTION
I noticed that the OSX runs were using Python 3.14 for all runs. Maybe setting up Python with uv will fix this.